### PR TITLE
feat: replace @typescript-eslint packages with typescript-eslint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,11 @@
       "dependencies": {
         "@eslint/js": "9.22.0",
         "@types/eslint": "9.6.1",
-        "@typescript-eslint/eslint-plugin": "8.26.0",
-        "@typescript-eslint/parser": "8.26.0",
         "eslint": "9.22.0",
         "eslint-config-prettier": "10.1.1",
         "eslint-plugin-svelte": "3.1.0",
         "svelte-eslint-parser": "1.0.1",
+        "typescript-eslint": "8.26.0",
       },
       "devDependencies": {
         "@jill64/prettier-config": "1.0.0",
@@ -311,6 +310,8 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
+
+    "typescript-eslint": ["typescript-eslint@8.26.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.26.0", "@typescript-eslint/parser": "8.26.0", "@typescript-eslint/utils": "8.26.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
   "dependencies": {
     "@types/eslint": "9.6.1",
     "@eslint/js": "9.22.0",
-    "@typescript-eslint/eslint-plugin": "8.26.0",
-    "@typescript-eslint/parser": "8.26.0",
+    "typescript-eslint": "8.26.0",
     "eslint": "9.22.0",
     "eslint-config-prettier": "10.1.1",
     "eslint-plugin-svelte": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jill64/eslint-config-svelte",
   "description": "🔹Pre-Defined ESLint Flat Config for Svelte",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/eslint-config-svelte.git",
-    "image": "https://opengraph.githubassets.com/af48e5d5f6eb045f96d2b5b40c437bd2ff3d62c41a767db017f03c38c8901c88/jill64/eslint-config-svelte"
+    "image": "https://opengraph.githubassets.com/6c6cf4611ace558f1d2d451663a971cf2f0701cb4ef96258160d37252c0c80d7/jill64/eslint-config-svelte"
   },
   "publishConfig": {
     "access": "public"

--- a/src/svelteConfig.ts
+++ b/src/svelteConfig.ts
@@ -1,15 +1,17 @@
 import js from '@eslint/js'
+import type { Linter } from 'eslint'
 import prettier from 'eslint-config-prettier'
 import svelte from 'eslint-plugin-svelte'
 import svelteParser from 'svelte-eslint-parser'
 import { FlatConfig } from './index.js'
-import type { Linter } from 'eslint'
 
 export const svelteConfig = (options?: {
   tsConfigPath?: string
   ignores?: string[]
   svelteRules?: Linter.RulesRecord | undefined
 }): FlatConfig[] => [
+  js.configs.recommended,
+  ...svelte.configs.recommended,
   {
     files: ['**/*.{js,jsx,cjs,mjs,svelte}']
   },
@@ -37,13 +39,7 @@ export const svelteConfig = (options?: {
     },
     rules: {
       ...options?.svelteRules
-    },
-    ...svelte.configs.base,
-    ...svelte.configs.recommended
-  },
-  {
-    ignores: ['**/*.svelte'],
-    ...js.configs.recommended
+    }
   },
   prettier
 ]

--- a/src/svelteTsConfig.ts
+++ b/src/svelteTsConfig.ts
@@ -1,6 +1,5 @@
 import js from '@eslint/js'
-import ts from '@typescript-eslint/eslint-plugin'
-import tsParser from '@typescript-eslint/parser'
+import ts from 'typescript-eslint'
 import type { Linter } from 'eslint'
 import prettier from 'eslint-config-prettier'
 import svelte from 'eslint-plugin-svelte'
@@ -11,61 +10,41 @@ export const svelteTsConfig = (options?: {
   tsConfigPath?: string
   ignores?: string[]
   svelteRules?: Linter.RulesRecord | undefined
-}): FlatConfig[] => [
-  {
-    files: ['**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts,svelte}']
-  },
-  {
-    ignores: options?.ignores ?? [
-      'dist',
-      'build',
-      'coverage',
-      '*.config.{js,ts,cjs,mjs,cts,mts}',
-      '.svelte-kit',
-      '.vercel'
-    ]
-  },
-  {
-    plugins: {
-      // @ts-expect-error workaround until upstream update
-      '@typescript-eslint': ts
+}): FlatConfig[] =>
+  ts.config(
+    js.configs.recommended,
+    ts.configs.recommended,
+    ...svelte.configs.recommended,
+    {
+      files: ['**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts,svelte}']
     },
-    languageOptions: {
-      parser: tsParser,
-      parserOptions: {
-        project: [options?.tsConfigPath ?? './tsconfig.json'],
-        parser: '@typescript-eslint/parser',
-        extraFileExtensions: ['.svelte']
+    {
+      ignores: options?.ignores ?? [
+        'dist',
+        'build',
+        'coverage',
+        '*.config.{js,ts,cjs,mjs,cts,mts}',
+        '.svelte-kit',
+        '.vercel'
+      ]
+    },
+    {
+      ignores: ['**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}'],
+      plugins: {
+        svelte
+      },
+      processor: svelte.processors.svelte,
+      languageOptions: {
+        parser: svelteParser,
+        parserOptions: {
+          project: [options?.tsConfigPath ?? './tsconfig.json'],
+          parser: '@typescript-eslint/parser',
+          extraFileExtensions: ['.svelte']
+        }
+      },
+      rules: {
+        ...options?.svelteRules
       }
     },
-    rules: {
-      ...ts.configs.base.rules,
-      ...ts.configs.recommended.rules
-    }
-  },
-  {
-    ignores: ['**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}'],
-    plugins: {
-      svelte
-    },
-    processor: svelte.processors.svelte,
-    languageOptions: {
-      parser: svelteParser,
-      parserOptions: {
-        project: [options?.tsConfigPath ?? './tsconfig.json'],
-        parser: '@typescript-eslint/parser',
-        extraFileExtensions: ['.svelte']
-      }
-    },
-    rules: {
-      ...options?.svelteRules
-    },
-    ...svelte.configs.base,
-    ...svelte.configs.recommended
-  },
-  {
-    ignores: ['**/*.{ts,tsx,cts,mts,svelte}'],
-    ...js.configs.recommended
-  },
-  prettier
-]
+    prettier
+  ) as FlatConfig[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the package version to 2.2.0.
  - Consolidated TypeScript linting dependencies and refreshed the repository image reference.

- **Refactor**
  - Streamlined and re-ordered configuration settings for improved consistency in linting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->